### PR TITLE
Декоративные элементы главной страницы

### DIFF
--- a/source/index.html
+++ b/source/index.html
@@ -116,12 +116,12 @@
                 <dd class="main-featured__description">15 см</dd>
               </div>
             </dl>
+            <div class="main-featured__image"></div>
             <div class="main-featured__wrapper-bottom">
               <p class="main-featured__price">Цена: 990 руб.</p>
               <a class="main-featured__button button" href="#">ЗАКАЗАТЬ</a>
             </div>
           </header>
-          <div class="main-featured__image"></div>
         </div>
       </section>
       <div class="zigzag-line"></div>

--- a/source/index.html
+++ b/source/index.html
@@ -12,8 +12,10 @@
       <a class="page-header__logo" href="#"></a>
       <button class="page-header__toggle" type="button">
         <span class="visually-hidden">Открыть меню</span>
-        <svg width="20" height="14" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M20 0H0v2h20V0ZM20 6H0v2h20V6ZM20 12H0v2h20v-2Z" fill="#231F20"/></svg>
+        <!--<svg width="20" height="14" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M20 0H0v2h20V0ZM20 6H0v2h20V6ZM20 12H0v2h20v-2Z" fill="#231F20"/></svg>
+        -->
       </button>
+      <!-- Можно добавить класс main-nav--closed -->
       <nav class="main-nav">
         <div class="main-nav__wrapper">
           <ul class="main-nav__list site-list">

--- a/source/index.html
+++ b/source/index.html
@@ -10,13 +10,15 @@
 
     <header class="page-header">
       <a class="page-header__logo" href="#"></a>
-      <button class="page-header__toggle" type="button">
-        <span class="visually-hidden">Открыть меню</span>
-        <!--<svg width="20" height="14" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M20 0H0v2h20V0ZM20 6H0v2h20V6ZM20 12H0v2h20v-2Z" fill="#231F20"/></svg>
-        -->
-      </button>
       <!-- Можно добавить класс main-nav--closed -->
-      <nav class="main-nav">
+      <!-- Можно добавить класс main-nav--opened -->
+      <!-- Можно добавить класс main-nav--nojs -->
+      <nav class="main-nav main-nav--closed main-nav--nojs">
+        <button class="main-nav__toggle" type="button">
+          <span class="visually-hidden">Открыть меню</span>
+          <!--<svg width="20" height="14" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M20 0H0v2h20V0ZM20 6H0v2h20V6ZM20 12H0v2h20v-2Z" fill="#231F20"/></svg>
+          -->
+        </button>
         <div class="main-nav__wrapper">
           <ul class="main-nav__list site-list">
             <li class="site-list__item">
@@ -57,13 +59,29 @@
         </div>
       </nav>
     </header>
+    <script>
+      var navMain = document.querySelector('.main-nav');
+      var navToggle = document.querySelector('.main-nav__toggle');
+
+      navMain.classList.remove('main-nav--nojs');
+
+      navToggle.addEventListener('click', function() {
+        if (navMain.classList.contains('main-nav--closed')) {
+          navMain.classList.remove('main-nav--closed');
+          navMain.classList.add('main-nav--opened');
+        } else {
+          navMain.classList.add('main-nav--closed');
+          navMain.classList.remove('main-nav--opened');
+        }
+      });
+    </script>
 
     <main class="page-main">
       <h1 class="visually-hidden">Мишка - с заботой о домашнем уюте</h1>
       <section class="main-header">
         <div class="main-header__wrapper">
           <header class="main-header__header">
-            <h2 class="main-header__title">Милые штуки ручной работы для дома</h2>
+            <h2 class="main-header__title">Милые штуки <span class="main-header__span">ручной</span> работы для дома</h2>
           </header>
           <ul class="main-header__list">
             <li class="main-header__item main-header--interior">
@@ -98,12 +116,12 @@
                 <dd class="main-featured__description">15 см</dd>
               </div>
             </dl>
+            <div class="main-featured__wrapper-bottom">
+              <p class="main-featured__price">Цена: 990 руб.</p>
+              <a class="main-featured__button button" href="#">ЗАКАЗАТЬ</a>
+            </div>
           </header>
           <div class="main-featured__image"></div>
-          <div class="main-featured__wrapper-bottom">
-            <p class="main-featured__price">Цена: 990 руб.</p>
-            <a class="main-featured__button button" href="#">ЗАКАЗАТЬ</a>
-          </div>
         </div>
       </section>
       <div class="zigzag-line"></div>

--- a/source/less/components/about-advantages.less
+++ b/source/less/components/about-advantages.less
@@ -4,7 +4,7 @@
   padding: 0;
   position: relative;
 
-  @media (min-width: @mobile-width-only) {
+  @media (max-width: @mobile-width-only) {
     display: flex;
     flex-direction: column;
     flex-wrap: wrap;

--- a/source/less/components/about-feedback.less
+++ b/source/less/components/about-feedback.less
@@ -23,20 +23,17 @@
   margin: 0;
   color: @darken-blue-black;
 
-  @media (min-width: @mobile-width-only) {
+  @media (max-width: @mobile-width-only) {
     margin-bottom: 33px;
   }
-  /*
-  @media (min-width: @tablet-width) {
-  }
 
-  @media (min-width: @desktop-width) {
+  @media (min-width: @tablet-width) {
+    margin-bottom: 40px;
   }
-  */
 }
 
 .about-feedback__author-data {
-  @media (min-width: @mobile-width-only) {
+  @media (max-width: @mobile-width-only) {
     margin-bottom: 30px;
   }
   /*
@@ -56,23 +53,17 @@
 }
 
 .about-feedback__author-link {
+  display: block;
   font-style: normal;
   font-weight: 400;
   font-size: 17px;
   line-height: 30px;
   color: @darken-blue-black;
-
-  @media (min-width: @tablet-width) {
-    display: block;
-  }
-  /*
-  @media (min-width: @desktop-width) {
-  }
-  */
 }
 
 .about-feedback__toggle {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
 
   @media (min-width: @tablet-width) {
     grid-column: 4 / 5;
@@ -97,7 +88,7 @@
   line-height: 20px;
   color: @darken-blue-black;
 
-  @media (min-width: @mobile-width-only) {
+  @media (max-width: @mobile-width-only) {
     margin-top: 20px;
   }
 

--- a/source/less/components/about.less
+++ b/source/less/components/about.less
@@ -13,7 +13,7 @@
 }
 
 .about__wrapper {
-  @media (min-width: @mobile-width-only) {
+  @media (max-width: @mobile-width-only) {
     padding-left: 30px;
     padding-right: 30px;
     display: flex;
@@ -24,7 +24,7 @@
   @media (min-width: @tablet-width) {
     display: grid;
     grid-template-columns: repeat(4, 167px);
-    grid-template-rows: 60px 1fr 80px 52px 300px;
+    grid-template-rows: 60px 1fr 140px 52px 300px;
     padding-left: 50px;
     padding-right: 50px;
   }
@@ -39,7 +39,7 @@
   font-size: 25px;
   line-height: 30px;
 
-  @media (min-width: @mobile-width-only) {
+  @media (max-width: @mobile-width-only) {
     margin-top: 0;
     margin-bottom: 14px;
   }
@@ -47,6 +47,7 @@
   @media (min-width: @tablet-width) {
     font-size: 43px;
     line-height: 50px;
+    margin: 0;
   }
 
   @media (min-width: @desktop-width) {

--- a/source/less/components/contacts.less
+++ b/source/less/components/contacts.less
@@ -23,8 +23,6 @@
   @media (max-width: @mobile-width-only) {
     min-height: 818px;
     margin-top: 38px;
-    padding-left: 30px;
-    padding-right: 30px;
   }
 
   @media (min-width: @tablet-width) {
@@ -46,6 +44,8 @@
   font-size: 25px;
   line-height: 30px;
   margin: 0;
+  padding-left: 30px;
+  padding-right: 30px;
 
   @media (min-width: @tablet-width) {
     font-size: 43px;
@@ -56,6 +56,7 @@
   @media (min-width: @desktop-width) {
     grid-column: 2 /3;
     grid-row: 2 / 3;
+    padding: 0;
   }
 }
 
@@ -80,6 +81,8 @@
   font-size: 14px;
   line-height: 30px;
   display: grid;
+  padding-left: 30px;
+  padding-right: 30px;
 
   @media (max-width: @mobile-width-only) {
     grid-template-columns: 1fr;
@@ -97,13 +100,14 @@
     grid-template-columns: 1fr;
     grid-template-rows: 50px 100px;
     margin: 0;
+    padding: 0;
   }
 }
 
 .contacts__item {
   width: 100%;
   display: grid;
-  grid-template-columns: 85px 1fr;
+  grid-template-columns: 1fr 3fr;
 }
 
 .contacts__item:not(:last-child) {
@@ -115,10 +119,7 @@
 .contacts__parameter,
 .contacts__description {
   color: @darken-blue-black;
-
-  @media (min-width: @tablet-width) {
-    margin: 0;
-  }
+  margin: 0;
 }
 
 .contacts__description a {
@@ -138,9 +139,7 @@ a[href^="info@mimimishkashop.ru"] {
     background-image: url("../../img/map-mobile.jpg");
     width: 320px;
     height: 454px;
-    margin-right: auto;
     margin-bottom: 42px;
-    margin-left: auto;
   }
 
   @media (min-width: @tablet-width) {
@@ -173,6 +172,7 @@ a[href^="info@mimimishkashop.ru"] {
   color: @darken-blue-black;
   text-align: center;
   padding: 16px 40px;
+  margin: 0 30px;
 
   @media (min-width: @tablet-width) {
     padding: 16px 28px;
@@ -185,6 +185,7 @@ a[href^="info@mimimishkashop.ru"] {
   @media (min-width: @desktop-width) {
     grid-column: 2 / 3;
     grid-row: 4 / 5;
-    margin-bottom: 0;
+    margin: 0;
+    position: static;
   }
 }

--- a/source/less/components/contacts.less
+++ b/source/less/components/contacts.less
@@ -4,7 +4,7 @@
   font-style: normal;
   color: @font-regular;
 
-  @media (min-width: @mobile-width-only) {
+  @media (max-width: @mobile-width-only) {
     min-height: 818px;
     margin-top: 38px;
   }
@@ -20,7 +20,7 @@
 }
 
 .contacts__wrapper {
-  @media (min-width: @mobile-width-only) {
+  @media (max-width: @mobile-width-only) {
     min-height: 818px;
     margin-top: 38px;
     padding-left: 30px;
@@ -66,6 +66,7 @@
     height: 81px;
     position: absolute;
     right: 0;
+    top: -20px;
   }
 
   @media (min-width: @desktop-width) {
@@ -78,9 +79,9 @@
   font-weight: 400;
   font-size: 14px;
   line-height: 30px;
+  display: grid;
 
-  @media (min-width: @mobile-width-only) {
-    display: grid;
+  @media (max-width: @mobile-width-only) {
     grid-template-columns: 1fr;
     grid-template-rows: 1fr;
   }
@@ -101,10 +102,13 @@
 
 .contacts__item {
   width: 100%;
+  display: grid;
+  grid-template-columns: 85px 1fr;
+}
 
-  @media (min-width: @mobile-width-only) {
-    display: grid;
-    grid-template-columns: 85px 1fr;
+.contacts__item:not(:last-child) {
+  @media (max-width: @mobile-width-only) {
+    margin-bottom: 30px;
   }
 }
 
@@ -117,27 +121,41 @@
   }
 }
 
+.contacts__parameter {
+  @media (min-width: @tablet-width) {
+  }
+}
+
 .contacts__description a {
   text-decoration: none;
   color: @darken-blue-black;
 }
 
+a[href^="info@mimimishkashop.ru"] {
+  padding-bottom: 5px;
+  border-bottom: 1px solid @tiffany-link;
+}
+
 .contacts__map {
-  @media (min-width: @mobile-width-only) {
+  background-repeat: no-repeat;
+
+  @media (max-width: @mobile-width-only) {
     background-image: url("../../img/map-mobile.jpg");
     width: 320px;
     height: 454px;
-    position: relative;
-    right: 30px;
+    margin-right: auto;
     margin-bottom: 42px;
+    margin-left: auto;
   }
 
   @media (min-width: @tablet-width) {
     background-image: url("../../img/map-tablet.jpg");
     width: 768px;
     height: 457px;
+    position: relative;
     right: 50px;
     margin-top: 60px;
+    margin-bottom: 50px;
   }
 
   @media (min-width: @desktop-width) {
@@ -164,6 +182,9 @@
   @media (min-width: @tablet-width) {
     padding: 16px 28px;
     margin-bottom: 57px;
+    display: inline-block;
+    position: relative;
+    left: 33%;
   }
 
   @media (min-width: @desktop-width) {

--- a/source/less/components/contacts.less
+++ b/source/less/components/contacts.less
@@ -121,11 +121,6 @@
   }
 }
 
-.contacts__parameter {
-  @media (min-width: @tablet-width) {
-  }
-}
-
 .contacts__description a {
   text-decoration: none;
   color: @darken-blue-black;

--- a/source/less/components/contacts.less
+++ b/source/less/components/contacts.less
@@ -159,17 +159,16 @@
   line-height: 20px;
   color: @darken-blue-black;
   text-align: center;
+  padding: 16px 40px;
 
   @media (min-width: @tablet-width) {
-    display: inline-block;
-    position: relative;
-    left: 240px;
     padding: 16px 28px;
+    margin-bottom: 57px;
   }
 
   @media (min-width: @desktop-width) {
-    position: static;
     grid-column: 2 / 3;
     grid-row: 4 / 5;
+    margin-bottom: 0;
   }
 }

--- a/source/less/components/main-featured.less
+++ b/source/less/components/main-featured.less
@@ -1,22 +1,24 @@
 .main-featured {
   background-color: @base-bg-color;
 
-  @media (min-width: @mobile-width-only) {
+  @media (max-width: @mobile-width-only) {
     min-height: 795px;
   }
 
   @media (min-width: @tablet-width) {
     min-height: 520px;
     margin-top: 40px;
+    margin-bottom: 40px;
   }
 
   @media (min-width: @desktop-width) {
     min-height: 732px;
+    margin-bottom: 0;
   }
 }
 
 .main-featured__wrapper {
-  @media (min-width: @mobile-width-only) {
+  @media (max-width: @mobile-width-only) {
     padding-left: 30px;
     padding-right: 30px;
   }
@@ -33,7 +35,7 @@
   font-style: normal;
   color: @font-regular;
 
-  @media (min-width: @mobile-width-only) {
+  @media (max-width: @mobile-width-only) {
     display: flex;
     flex-direction: column;
     flex-wrap: nowrap;
@@ -42,12 +44,13 @@
   @media (min-width: @tablet-width) {
     display: grid;
     grid-template-columns: 292px 1fr 1fr;
-    grid-template-rows: 70px 140px 1fr;
+    grid-template-rows: 70px 140px 1fr 1fr;
+    align-items: center;
   }
 
   @media (min-width: @desktop-width) {
     grid-template-columns: repeat(6, 175px);
-    grid-template-rows: 33px 1fr 1fr 1fr;
+    grid-template-rows: 33px 1fr 1fr 1fr 33px 1fr;
   }
 }
 
@@ -56,7 +59,7 @@
   font-size: 25px;
   line-height: 30px;
 
-  @media (min-width: @mobile-width-only) {
+  @media (max-width: @mobile-width-only) {
     margin: 0;
     margin-bottom: 3px;
   }
@@ -105,7 +108,7 @@
   line-height: 24px;
   color: @darken-blue-black;
 
-  @media (min-width: @mobile-width-only) {
+  @media (max-width: @mobile-width-only) {
     margin-top: 17px;
     margin-bottom: 26px;
   }
@@ -157,7 +160,7 @@
 .main-featured__image {
   margin: 0 auto;
 
-  @media (min-width: @mobile-width-only) {
+  @media (max-width: @mobile-width-only) {
     background-image: url("../../img/triple-set-mobile.jpg");
     width: 260px;
     height: 315px;
@@ -168,7 +171,7 @@
     width: 334px;
     height: 404px;
     position: absolute;
-    top: 70px;
+    top: 100px;
     right: 50px;
   }
 
@@ -185,39 +188,37 @@
   font-style: normal;
   font-weight: 700;
 
-  @media (min-width: @mobile-width-only) {
+  @media (max-width: @mobile-width-only) {
     display: flex;
     flex-direction: column;
-    align-items: center;
   }
 
   @media (min-width: @tablet-width) {
-    position: relative;
-    left: -187px;
-    top: -5px;
+    grid-column: 1 / 2;
+    grid-row: 4 / 5;
   }
 
   @media (min-width: @desktop-width) {
-    left: -205px;
-    top: 55px;
+    grid-column: 2 / 3;
+    grid-row: 6 / 7;
   }
 }
 
 .main-featured__price {
+  font-weight: 700;
   font-size: 17px;
   line-height: 24px;
   color: @darken-blue-black;
+  margin: 25px 0;
+  width: inherit;
+  align-self: center;
+  text-align: center;
 
-  @media (min-width: @mobile-width-only) {
-    margin: 25px 0;
-    width: inherit;
-  }
-  /*
   @media (min-width: @tablet-width) {
+    font-size: 20px;
+    line-height: 24px;
+    margin-bottom: 62px;
   }
-
-  @media (min-width: @desktop-width) {
-  }*/
 }
 
 .main-featured__button {
@@ -225,12 +226,9 @@
   line-height: 20px;
   color: @darken-blue-black;
   text-decoration: none;
+  text-align: center;
 
   @media (min-width: @tablet-width) {
     padding: 16px 100px;
   }
-
-  /*
-  @media (min-width: @desktop-width) {
-  }*/
 }

--- a/source/less/components/main-featured.less
+++ b/source/less/components/main-featured.less
@@ -82,8 +82,8 @@
 
 .main-featured__weekly {
   font-weight: 700;
-  font-size: 25px;
-  line-height: 30px;
+  font-size: 17px;
+  line-height: 20px;
   color: @tiffany-lighter;
 
   @media (min-width: @tablet-width) {
@@ -127,8 +127,9 @@
   font-weight: 400;
   font-size: 15px;
   line-height: 20px;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: auto;
   margin: 0;
   margin-bottom: 28px;
 
@@ -143,15 +144,16 @@
 }
 
 .main-featured__item {
-  width: 100%;
+  display: grid;
+  width: inherit;
+  grid-template-columns: 50% 50%;
+  grid-template-rows: 1fr;
   padding: 8px 0;
   border-bottom: 1px solid @thin-grey-line;
 }
 
 .main-featured__parameter,
 .main-featured__description {
-  float: left;
-  width: 50%;
   padding: 0;
   margin: 0;
   color: @darken-blue-black;
@@ -199,7 +201,7 @@
   }
 
   @media (min-width: @desktop-width) {
-    grid-column: 2 / 3;
+    grid-column: 2 / 4;
     grid-row: 6 / 7;
   }
 }
@@ -218,6 +220,10 @@
     font-size: 20px;
     line-height: 24px;
     margin-bottom: 62px;
+  }
+
+  @media (min-width: @desktop-width) {
+    padding-right: 40px;
   }
 }
 

--- a/source/less/components/main-featured.less
+++ b/source/less/components/main-featured.less
@@ -26,10 +26,6 @@
     padding-right: 50px;
     position: relative;
   }
-  /*
-  @media (min-width: @desktop-width) {
-    min-height: 763px;
-  */
 }
 
 .main-featured-header {
@@ -198,7 +194,7 @@
   @media (min-width: @tablet-width) {
     position: relative;
     left: -187px;
-    top: 55px;
+    top: -5px;
   }
 
   @media (min-width: @desktop-width) {

--- a/source/less/components/main-header.less
+++ b/source/less/components/main-header.less
@@ -37,21 +37,20 @@
   position: absolute;
 
   @media (max-width: @mobile-width-only) {
-    top: 50px;
-    left: 65px;
-    padding: 30px;
-    margin: 0 auto;
+    top: 18%;
+    left: 10%;
+    right: 10%;
   }
 
   @media (min-width: @tablet-width) {
-    top: 160px;
-    left: 155px;
-    width: 460px;
+    width: 70%;
+    top: 22%;
+    left: 15%;
+    right: 15%;
   }
 
   @media (min-width: @desktop-width) {
-    width: 580px;
-    left: 368px;
+    width: 67%;
   }
 }
 

--- a/source/less/components/main-header.less
+++ b/source/less/components/main-header.less
@@ -5,7 +5,7 @@
   background-repeat: no-repeat;
   background-position: top center;
 
-  @media (min-width: @mobile-width-only) {
+  @media (max-width: @mobile-width-only) {
     min-height: 506px;
   }
 
@@ -34,9 +34,13 @@
 }
 
 .main-header__header {
-  @media (min-width: @mobile-width-only) {
-    position: absolute;
-    top: 92px;
+  position: absolute;
+
+  @media (max-width: @mobile-width-only) {
+    top: 50px;
+    left: 65px;
+    padding: 30px;
+    margin: 0 auto;
   }
 
   @media (min-width: @tablet-width) {
@@ -47,7 +51,7 @@
 
   @media (min-width: @desktop-width) {
     width: 580px;
-    left: 284px;
+    left: 368px;
   }
 }
 
@@ -72,12 +76,18 @@
   }
 }
 
+.main-header__span {
+  @media (max-width: @mobile-width-only) {
+    display: block;
+  }
+}
+
 .main-header__list {
   margin: 0;
   padding: 0;
   list-style-type: none;
 
-  @media (min-width: @mobile-width-only) {
+  @media (max-width: @mobile-width-only) {
     min-height: 506px;
     margin: 0 auto 31px;
     display: flex;
@@ -93,10 +103,6 @@
     grid-template-rows: 1fr;
     align-items: end;
   }
-  /*
-  @media (min-width: @desktop-width) {
-  }
-  */
 }
 
 .main-header--interior,
@@ -111,18 +117,13 @@
   color: @font-white;
   margin: 0;
 
-  @media (min-width: @mobile-width-only) {
+  @media (max-width: @mobile-width-only) {
     padding: 24px 50px 27px 30px;
   }
 
   @media (min-width: @tablet-width) {
     padding: 34px 50px 34px 36px;
   }
-  /*
-  @media (min-width: @desktop-width) {
-    max-width: 1200px;
-  }
-  */
 }
 
 .main-header--interior {

--- a/source/less/components/main-nav.less
+++ b/source/less/components/main-nav.less
@@ -116,6 +116,7 @@
   @media (min-width: @tablet-width) {
     display: flex;
     flex-direction: row;
+    flex-wrap: wrap;
   }
 }
 

--- a/source/less/components/main-nav.less
+++ b/source/less/components/main-nav.less
@@ -8,15 +8,18 @@
 
 .main-nav__wrapper {
   position: relative;
-  display: flex;
-  flex-direction: column;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: auto;
 
   @media (min-width: @tablet-width) {
-    position: relative;
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: space-between;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: 89px 1fr;
+    align-items: center;
+  }
+
+  @media (min-width: @desktop-width) {
+    grid-template-columns: 1fr 1fr 1fr;
   }
 }
 
@@ -30,6 +33,7 @@
   }
 
   @media (min-width: @tablet-width) {
+    display: flex;
     flex-direction: row;
   }
   /*
@@ -55,12 +59,12 @@
   }
 
   @media (min-width: @desktop-width) {
+    grid-column: 1 / 2;
+    grid-row: 2 / 3;
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
     width: 260px;
-    position: absolute;
-    top: 20px;
   }
 }
 
@@ -81,19 +85,37 @@
   }
 
   @media (min-width: @tablet-width) {
+    background-color: @header-bg-color;
     display: inline-block;
-    position: absolute;
-    top: 20px;
-    right: 0;
+    grid-column: 2 / 3;
+    grid-row: 2 / 3;
     font-family: "Open Sans", "Arial", sans-serif;
     font-weight: 400;
     font-style: normal;
     font-size: 15px;
     line-height: 24px;
+    text-align: center;
     color: @darken-blue-black;
   }
-  /*
+
   @media (min-width: @desktop-width) {
+    grid-column: 3 / 4;
+    grid-row: 2 / 3;
   }
-  */
+}
+
+.page-header__toggle::before {
+  content: "";
+  position: absolute;
+  top: 32px;
+  left: 31px;
+  width: 20px;
+  height: 2px;
+  background-color: @button-menu;
+  box-shadow: 0 8px 0 0 @button-menu, 0 16px 0 0 @button-menu;
+}
+
+.page-header__toggle:active::before {
+  background-color: fade(@button-menu, 30%);
+  box-shadow: 0 8px 0 0 fade(@button-menu, 30%), 0 16px 0 0 fade(@button-menu, 30%);
 }

--- a/source/less/components/main-nav.less
+++ b/source/less/components/main-nav.less
@@ -1,9 +1,90 @@
 .main-nav {
   background-color: @base-bg-color;
+}
+
+@media (max-width: @mobile-width-only) {
+  .main-nav--closed .site-list__item {
+    display: none;
+  }
+
+  .main-nav--closed .user-list__item {
+    display: none;
+  }
+}
+
+.main-nav--nojs .main-nav__toggle {
+  display: none;
+}
+
+.main-nav--nojs .main-nav__wrapper {
+  position: static;
+  min-height: 0;
+}
+
+.main-nav__toggle {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 80px;
+  height: 80px;
+  border: none;
+  background-color: transparent;
+  cursor: pointer;
+  z-index: 2;
   /*
-  outline: 5px solid #ff0000;
-  outline-offset: -5px;
+  &:active,
+  &:hover {
+  }
   */
+  @media (min-width: @tablet-width) {
+    display: none;
+  }
+}
+
+.main-nav--opened .main-nav__toggle {
+  top: 0;
+  right: 0;
+
+  &::before,
+  &::after {
+    content: "";
+    position: absolute;
+    top: 40px;
+    left: 30px;
+    width: 30px;
+    height: 2px;
+    background-color: @button-menu;
+  }
+
+  &::before {
+    transform: rotate(45deg);
+    box-shadow: none;
+  }
+
+  &::after {
+    transform: rotate(-45deg);
+  }
+
+  &:active::before,
+  &:active::after {
+    background-color: fade(#ffffff, 30%);
+  }
+}
+
+.main-nav--closed .main-nav__toggle::before {
+  content: "";
+  position: absolute;
+  top: 32px;
+  left: 31px;
+  width: 20px;
+  height: 2px;
+  background-color: @button-menu;
+  box-shadow: 0 8px 0 0 @button-menu, 0 16px 0 0 @button-menu;
+}
+
+.main-nav--closed .main-nav__toggle:active::before {
+  background-color: fade(@button-menu, 30%);
+  box-shadow: 0 8px 0 0 fade(@button-menu, 30%), 0 16px 0 0 fade(@button-menu, 30%);
 }
 
 .main-nav__wrapper {
@@ -28,7 +109,7 @@
   margin: 0;
   padding: 0;
 
-  @media (min-width: @mobile-width-only) {
+  @media (max-width: @mobile-width-only) {
     display: block;
   }
 
@@ -36,10 +117,6 @@
     display: flex;
     flex-direction: row;
   }
-  /*
-  @media (min-width: @desktop-width) {
-  }
-  */
 }
 
 .main-nav__wrapper--form {
@@ -54,7 +131,7 @@
 }
 
 .main-nav__list--sub {
-  @media (min-width: @mobile-width-only) {
+  @media (max-width: @desktop-width) {
     display: none;
   }
 
@@ -80,7 +157,7 @@
 }
 
 .main-nav__list--option {
-  @media (min-width: @mobile-width-only) {
+  @media (max-width: @mobile-width-only) {
     display: none;
   }
 
@@ -94,7 +171,7 @@
     font-style: normal;
     font-size: 15px;
     line-height: 24px;
-    text-align: center;
+    text-align: end;
     color: @darken-blue-black;
   }
 
@@ -102,20 +179,4 @@
     grid-column: 3 / 4;
     grid-row: 2 / 3;
   }
-}
-
-.page-header__toggle::before {
-  content: "";
-  position: absolute;
-  top: 32px;
-  left: 31px;
-  width: 20px;
-  height: 2px;
-  background-color: @button-menu;
-  box-shadow: 0 8px 0 0 @button-menu, 0 16px 0 0 @button-menu;
-}
-
-.page-header__toggle:active::before {
-  background-color: fade(@button-menu, 30%);
-  box-shadow: 0 8px 0 0 fade(@button-menu, 30%), 0 16px 0 0 fade(@button-menu, 30%);
 }

--- a/source/less/components/page-footer.less
+++ b/source/less/components/page-footer.less
@@ -42,6 +42,9 @@
 }
 
 .page-footer__social {
+  display: flex;
+  flex-direction: column;
+
   @media (max-width: @mobile-width-only) {
     border-bottom: 1px solid @thin-grey-line;
   }
@@ -73,11 +76,6 @@
   @media (min-width: @tablet-width) {
     margin-right: 30px;
   }
-}
-
-.page-footer__link {
-  background-image: url("../../img/insta.svg");
-  background-repeat: no-repeat;
 }
 
 .page-footer__copyright {

--- a/source/less/components/page-footer.less
+++ b/source/less/components/page-footer.less
@@ -3,11 +3,12 @@
 }
 
 .page-footer__wrapper {
-  @media (min-width: @mobile-width-only) {
-    display: grid;
+  display: grid;
+  grid-row-gap: 20px;
+
+  @media (max-width: @mobile-width-only) {
     grid-template-columns: 1fr;
     grid-template-rows: 1fr 1fr;
-    grid-row-gap: 20px;
     padding: 25px 30px;
   }
 
@@ -16,15 +17,12 @@
     grid-template-rows: 1fr;
     padding: 51px 50px 58px;
   }
-  /*
-  @media (min-width: @desktop-width) {
-  }
-  */
 }
 
 .page-footer__logo {
-  @media (min-width: @mobile-width-only) {
-    position: absolute;
+  position: absolute;
+
+  @media (max-width: @mobile-width-only) {
     width: 1px;
     height: 1px;
     margin: -1px;
@@ -41,38 +39,23 @@
     height: 34px;
     position: static;
   }
-  /*
-  @media (min-width: @desktop-width) {
-  }
-  */
 }
 
 .page-footer__social {
-  @media (min-width: @mobile-width-only) {
+  @media (max-width: @mobile-width-only) {
     border-bottom: 1px solid @thin-grey-line;
   }
-  /*
-  @media (min-width: @tablet-width) {
-  }
-
-  @media (min-width: @desktop-width) {
-  }
-  */
 }
 
 .page-footer__list {
   list-style-type: none;
   margin: 0;
   padding: 0;
-
-  @media (min-width: @mobile-width-only) {
-    display: grid;
-    grid-template-columns: 1fr 1fr 1fr;
-    grid-template-rows: 1fr;
-    list-style-type: none;
-    align-items: center;
-    justify-items: center;
-  }
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-rows: 1fr;
+  align-items: center;
+  justify-items: center;
 
   @media (min-width: @desktop-width) {
     margin: 0 50px;
@@ -90,10 +73,6 @@
   @media (min-width: @tablet-width) {
     margin-right: 30px;
   }
-  /*
-  @media (min-width: @desktop-width) {
-  }
-  */
 }
 
 .page-footer__link {
@@ -102,17 +81,11 @@
 }
 
 .page-footer__copyright {
-  @media (min-width: @mobile-width-only) {
-    display: flex;
-    justify-content: space-around;
-    align-items: center;
-  }
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
 
   @media (min-width: @tablet-width) {
     justify-content: flex-end;
   }
-  /*
-  @media (min-width: @desktop-width) {
-  }
-  */
 }

--- a/source/less/components/page-header.less
+++ b/source/less/components/page-header.less
@@ -5,7 +5,7 @@
   background-color: @base-bg-color;
   color: @font-regular;
 
-  @media (min-width: @mobile-width-only) {
+  @media (max-width: @mobile-width-only) {
     border-top: 1px solid @thin-grey-line;
     border-bottom: 1px solid @thin-grey-line;
   }
@@ -17,7 +17,7 @@
 }
 
 .page-header__logo {
-  @media (min-width: @mobile-width-only) {
+  @media (max-width: @mobile-width-only) {
     background-image: url("../../img/logotype-mobile.svg");
     background-repeat: no-repeat;
     width: 86px;
@@ -32,6 +32,7 @@
     margin-left: 0;
     margin-right: auto;
     position: absolute;
+    top: 22px;
   }
 
   @media (min-width: @desktop-width) {
@@ -41,24 +42,5 @@
     margin: 0 auto;
     left: 43%;
     top: 10px;
-  }
-}
-
-.page-header__toggle {
-  position: absolute;
-  right: 0;
-  width: 80px;
-  height: 80px;
-  border: none;
-  background-color: transparent;
-  cursor: pointer;
-  z-index: 2;
-  /*
-  &:active,
-  &:hover {
-  }
-  */
-  @media (min-width: @tablet-width) {
-    display: none;
   }
 }

--- a/source/less/components/page-header.less
+++ b/source/less/components/page-header.less
@@ -31,6 +31,7 @@
     height: 46px;
     margin-left: 0;
     margin-right: auto;
+    position: absolute;
   }
 
   @media (min-width: @desktop-width) {
@@ -38,21 +39,26 @@
     width: 149px;
     height: 72px;
     margin: 0 auto;
+    left: 43%;
+    top: 10px;
   }
 }
 
 .page-header__toggle {
   position: absolute;
   right: 0;
+  width: 80px;
+  height: 80px;
   border: none;
-  background: transparent;
-  padding: 32px;
-
-  @media (min-width: @tablet-width) {
-    display: none;
+  background-color: transparent;
+  cursor: pointer;
+  z-index: 2;
+  /*
+  &:active,
+  &:hover {
   }
-
-  @media (min-width: @desktop-width) {
+  */
+  @media (min-width: @tablet-width) {
     display: none;
   }
 }

--- a/source/less/components/page.less
+++ b/source/less/components/page.less
@@ -1,8 +1,16 @@
 .page__body {
   min-height: 100%;
-  margin: 0;
+  margin: 0 auto;
+
+  @media (max-width: @mobile-width-only) {
+    width: 320px;
+  }
+
+  @media (min-width: @tablet-width) {
+    width: 772px;
+  }
 
   @media (min-width: @desktop-width) {
-    margin: 0 50px;
+    width: 1150px;
   }
 }

--- a/source/less/components/page.less
+++ b/source/less/components/page.less
@@ -1,18 +1,8 @@
 .page__body {
-  width: 100%;
   min-height: 100%;
-  margin-left: auto;
-  margin-right: auto;
-
-  @media (min-width: @mobile-width-only) {
-    width: 320px;
-  }
-
-  @media (min-width: @tablet-width) {
-    width: 768px;
-  }
+  margin: 0;
 
   @media (min-width: @desktop-width) {
-    width: 1150px;
+    margin: 0 50px;
   }
 }

--- a/source/less/components/site-list.less
+++ b/source/less/components/site-list.less
@@ -2,7 +2,7 @@
   @media (min-width: @tablet-width) {
     grid-column: 1 / 2;
     grid-row: 2 / 3;
-    width: 390px;
+    width: 340px;
     background-color: @header-bg-color;
   }
 
@@ -16,7 +16,7 @@
 }
 
 .site-list__item {
-  @media (min-width: @mobile-width-only) {
+  @media (max-width: @mobile-width-only) {
     border-top: 1px solid @thin-grey-line;
     padding: 28px 52px 27px 76px;
   }

--- a/source/less/components/site-list.less
+++ b/source/less/components/site-list.less
@@ -1,14 +1,17 @@
 .site-list {
   @media (min-width: @tablet-width) {
-    position: absolute;
-    display: flex;
-    flex-wrap: wrap;
+    grid-column: 1 / 2;
+    grid-row: 2 / 3;
     width: 390px;
+    background-color: @header-bg-color;
   }
 
   @media (min-width: @desktop-width) {
+    grid-column: 1 / 2;
+    grid-row: 1 / 2;
     width: 430px;
     top: -65px;
+    background-color: transparent;
   }
 }
 

--- a/source/less/components/user-list.less
+++ b/source/less/components/user-list.less
@@ -15,7 +15,7 @@
 }
 
 .user-list__item {
-  @media (min-width: @mobile-width-only) {
+  @media (max-width: @mobile-width-only) {
     border-top: 1px solid @thin-grey-line;
     padding: 28px 52px 27px 76px;
     min-height: 20px;
@@ -25,10 +25,22 @@
     border-top: none;
     padding: 0;
   }
-  /*
-  @media (min-width: @desktop-width) {
+}
+
+.user-list__item:first-child {
+  @media (min-width: @tablet-width) {
+    text-align: center;
   }
-  */
+
+  @media (min-width: @desktop-width) {
+    text-align: left;
+  }
+}
+
+.user-list__item:last-child {
+  @media (min-width: @tablet-width) {
+    text-align: end;
+  }
 }
 
 .user-list__link {
@@ -43,7 +55,7 @@
 }
 
 .user-list__item:first-child::after {
-  @media (min-width: @mobile-width-only) {
+  @media (max-width: @mobile-width-only) {
     content: "Поиск по сайту";
     position: absolute;
     display: block;
@@ -68,7 +80,7 @@
 .user-list__icon {
   position: absolute;
 
-  @media (min-width: @mobile-width-only) {
+  @media (max-width: @mobile-width-only) {
     left: -41px;
     top: -2px;
   }

--- a/source/less/components/user-list.less
+++ b/source/less/components/user-list.less
@@ -1,8 +1,7 @@
 .user-list {
   @media (min-width: @tablet-width) {
-    position: absolute;
-    right: 0;
-    top: -55px;
+    grid-column: 2 / 3;
+    grid-row: 1 / 2;
     display: grid;
     grid-template-columns: 80px 1fr;
     grid-template-rows: 1fr;
@@ -10,6 +9,8 @@
 
   @media (min-width: @desktop-width) {
     top: -45px;
+    grid-column: 3 / 4;
+    grid-row: 1 / 2;
   }
 }
 

--- a/source/less/components/user-list.less
+++ b/source/less/components/user-list.less
@@ -29,7 +29,7 @@
 
 .user-list__item:first-child {
   @media (min-width: @tablet-width) {
-    text-align: center;
+    text-align: end;
   }
 
   @media (min-width: @desktop-width) {
@@ -83,5 +83,11 @@
   @media (max-width: @mobile-width-only) {
     left: -41px;
     top: -2px;
+  }
+
+  @media (min-width: @tablet-width) {
+    position: relative;
+    right: 40px;
+    top: 2px;
   }
 }

--- a/source/less/variables/variables.less
+++ b/source/less/variables/variables.less
@@ -23,7 +23,6 @@
 @font-white: #ffffff;
 
 // viewports
-// было 320px
 @mobile-width-only: 767px;
 @tablet-width: 768px;
 @desktop-width: 1150px;

--- a/source/less/variables/variables.less
+++ b/source/less/variables/variables.less
@@ -10,9 +10,10 @@
 // Для границ кнопок и волнистой линии
 @thin-grey-line: #ececec;
 
-// Цвета плиток в main-header.less
+// Цвета Тиффани
 @tiffany-lighter: #63d1bb;
 @tiffany-darker: #56c3b2;
+@tiffany-link: #62d1ba;
 
 // Цвет page-footer на главной странице, хедера на внутренней странице
 @base-grey-color: #f1f1f1;
@@ -22,6 +23,7 @@
 @font-white: #ffffff;
 
 // viewports
-@mobile-width-only: 320px;
+// было 320px
+@mobile-width-only: 767px;
 @tablet-width: 768px;
 @desktop-width: 1150px;

--- a/source/less/variables/variables.less
+++ b/source/less/variables/variables.less
@@ -1,4 +1,5 @@
 @base-bg-color: #ffffff;
+@header-bg-color: #f9f9f9;
 
 // Для развертываемой кнопки меню
 @button-menu: #231f20;


### PR DESCRIPTION
Исправлено:
 - переделана шапка сайта с абсолютного позиционирования под гриды
 - тоггл-кнопка заменена с свг-изображения на css-стили

Не до конца понял как:
 - растянуть элементы, прилегающие на макете к краям: пробовал флексы и width: 100%, не вышло :(

В течение следующих трех дней исправлю:
 - абсолютное позиционирование у логитипа-ссылки, так как теперь он не восприимчив к переносу на главную страницу
 - добавлю JS для тоггла
 - и с удовольствием карту, но тогда нужен совет по стилизации булавки (точка на карте)


---
:mortar_board: [Декоративные элементы главной страницы](https://up.htmlacademy.ru/adaptive/24/user/1872127/tasks/9)

:boom: https://htmlacademy-adaptive.github.io/1872127-mishka-24/9/